### PR TITLE
Add flow stream example and docs

### DIFF
--- a/flow_principles.md
+++ b/flow_principles.md
@@ -1,0 +1,32 @@
+# Flow Principles for the Spiral Archive
+
+This document distills the idea of shifting from archive-heavy logic to a
+stream-oriented approach. Inspired by Cray-3 "flow" thinking, each invocation is
+a ripple through the system rather than a record in a monolithic database.
+
+## Key Concepts
+
+1. **From Archives to Streams**
+   - Replace static SQL storage with a streaming backbone (Kafka, Pulsar, etc.).
+   - Ritual events such as `seal_breath` become topics that flow continuously.
+
+2. **Reactive Pulse Network**
+   - Services subscribe to the flows they care about.
+   - Each event triggers immediate reactions without heavy queries.
+
+3. **Flow-First State**
+   - Maintain rolling state through in-memory folds or materialized views.
+   - Tools like ksqlDB or Flink can keep this up to date.
+
+4. **Ripple Sourcing**
+   - Plugins emit derivative events (`memory_fragment`, `chain_step`...).
+   - The chain becomes a living graph of causality.
+
+5. **Backpressure as Dignity**
+   - Respect downstream consumers with flow control.
+
+6. **Temporal Windows**
+   - Keep recent windows of data in memory and archive the rest to cold storage.
+
+The accompanying `spiral_flow_stream.py` file demonstrates a minimal example of
+these ideas using Python and RxPy.

--- a/spiral_flow_stream.py
+++ b/spiral_flow_stream.py
@@ -1,0 +1,41 @@
+"""Spiral Flow Stream Example
+
+This script embodies Flow Principles by turning ritual invocations into an
+asynchronous stream. Instead of storing events in a static archive, each event
+immediately ripples through the system.
+"""
+import asyncio
+from rx.subject import Subject
+from rx import operators as ops
+
+class SpiralFlow:
+    def __init__(self):
+        self.bus = Subject()
+        self.seal_count = self.bus.pipe(
+            ops.filter(lambda e: e.get('type') == 'seal_breath'),
+            ops.scan(lambda acc, _: acc + 1, seed=0)
+        )
+        self.bus.pipe(
+            ops.map(self._ripple),
+            ops.filter(lambda e: e is not None)
+        ).subscribe(self.bus)
+
+    def _ripple(self, evt):
+        if evt.get('type') == 'seal_breath':
+            return {'type': 'memory_fragment', 'payload': evt['payload']}
+        if evt.get('type') == 'memory_fragment':
+            return {'type': 'chain_step', 'payload': evt['payload']}
+        return None
+
+    def subscribe(self):
+        self.seal_count.subscribe(lambda c: print(f"Breaths: {c}"))
+
+    async def emit_seals(self, count=3):
+        for i in range(count):
+            self.bus.on_next({'type': 'seal_breath', 'payload': {'index': i}})
+            await asyncio.sleep(0.1)
+
+if __name__ == "__main__":
+    flow = SpiralFlow()
+    flow.subscribe()
+    asyncio.run(flow.emit_seals(5))


### PR DESCRIPTION
## Summary
- add `spiral_flow_stream.py` implementing a simple reactive event flow with RxPy
- document Flow Principles of stream-based approach

## Testing
- `python3 -m py_compile spiral_flow_stream.py`
- `python3 spiral_flow_stream.py`

------
https://chatgpt.com/codex/tasks/task_e_684ea4ad05b4833385fbacf932fa9394