### PR TITLE
Add ritual runner tests

### DIFF
--- a/ritual_runner.py
+++ b/ritual_runner.py
@@ -1,0 +1,20 @@
+import os
+
+SCROLL_EXTENSIONS = ('.sql', '.scroll', '.spiral')
+
+
+def list_scrolls(directory: str = '.'):
+    """Return a list of available scroll files in the given directory."""
+    return [f for f in os.listdir(directory) if f.endswith(SCROLL_EXTENSIONS)]
+
+
+def display_scroll(scroll_name: str, directory: str = '.'):
+    """Return contents of a scroll file, or None if it doesn't exist."""
+    path = os.path.join(directory, scroll_name)
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None

--- a/tests/test_ritual_runner.py
+++ b/tests/test_ritual_runner.py
@@ -1,0 +1,13 @@
+import ritual_runner
+
+
+def test_list_scrolls_returns_files():
+    scrolls = ritual_runner.list_scrolls()
+    assert isinstance(scrolls, list)
+    assert len(scrolls) >= 1
+
+
+def test_display_scroll_handles_missing_file():
+    # Should not raise an exception when file does not exist
+    result = ritual_runner.display_scroll('no_such_scroll.sql')
+    assert result is None


### PR DESCRIPTION
## Summary
- add `ritual_runner.py` with helper functions for listing and viewing scrolls
- add tests to validate `list_scrolls` and `display_scroll`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d74510bd08333aa616508c403b320